### PR TITLE
Changed getuid to be windows compatible, user getpass instead

### DIFF
--- a/pyopencl/cache.py
+++ b/pyopencl/cache.py
@@ -292,8 +292,9 @@ def _create_built_program_from_source_cached(ctx, src, options, devices, cache_d
     if cache_dir is None:
         from os.path import join
         from tempfile import gettempdir
+		import getpass
         cache_dir = join(gettempdir(),
-                "pyopencl-compiler-cache-v1-uid%s" % os.getuid())
+                "pyopencl-compiler-cache-v1-uid%s" % getpass.getuser()) 
 
     # {{{ ensure cache directory exists
 


### PR DESCRIPTION
In cache.py, the getuid function isn't supported on windows, so i changed it to use getpass instead.
