### PR TITLE
Import Image from the PIL namespace

### DIFF
--- a/examples/demo_mandelbrot.py
+++ b/examples/demo_mandelbrot.py
@@ -108,8 +108,7 @@ calc_fractal = calc_fractal_opencl
 
 if __name__ == '__main__':
     import Tkinter as tk
-    import Image          # PIL
-    import ImageTk        # PIL
+    from PIL import Image, ImageTk
 
 
     class Mandelbrot(object):


### PR DESCRIPTION
Fixes import error when using Pillow, a PIL fork with many bug fixes and Python 3 compatibility.
