### PR TITLE
Replaced the link to obsolete Pyfft with the link to Reikna.

### DIFF
--- a/doc/array.rst
+++ b/doc/array.rst
@@ -275,8 +275,9 @@ Generating Arrays of Random Numbers
     .. autofunction:: rand
     .. autofunction:: fill_rand
 
-Fast Fourier Transforms
------------------------
+GPGPU Algorithms
+----------------
 
-Bogdan Opanchuk's `pyfft <http://pypi.python.org/pypi/pyfft>`_ package offers a
-variety of GPU-based FFT implementations.
+Bogdan Opanchuk's `reikna <http://pypi.python.org/pypi/reikna>`_ offers a
+variety of GPU-based algorithms (FFT, RNG, matrix multiplication) designed to work with
+:class:`pyopencl.array.Array` objects.


### PR DESCRIPTION
Reikna is stable enough now to serve as a replacement. Or, alternatively, you can close this PR and remove this section altogether; I do not want people to get the wrong idea about Pyfft status.

If this section stays in docs, perhaps other people would want to add links to their packages as well.

(Yep, this is the exact duplicate of PyCUDA PR)
