### PR TITLE
Fixed an obsolete access to ``obj_ptr`` attribute.

### DIFF
--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -314,7 +314,7 @@ def _add_functionality():
     # {{{ Context
 
     def context_repr(self):
-        return "<pyopencl.Context at 0x%x on %s>" % (self.obj_ptr,
+        return "<pyopencl.Context at 0x%x on %s>" % (self.int_ptr,
                 ", ".join(repr(dev) for dev in self.devices))
 
     def context_get_cl_version(self):


### PR DESCRIPTION
`obj_ptr` was replaced by `int_ptr` everywhere since commit e1f7d40ab885dfbf35fde3405ac1931a584bb6a2. This entry seems to have been forgotten.
