### PR TITLE
Fallback on file copy on failure to symlink boost.

### DIFF
--- a/aksetup_helper.py
+++ b/aksetup_helper.py
@@ -559,12 +559,11 @@ def set_up_shipped_boost_if_requested(project_name, conf):
         if not isdir(bpl_project_boost_inc):
             try:
                 from os import symlink
-            except ImportError:
+                symlink("boost", bpl_project_boost_inc)
+            except (ImportError, OSError):
                 from shutil import copytree
                 print("Copying files, hang on... (do not interrupt)")
                 copytree(main_boost_inc, bpl_project_boost_inc)
-            else:
-                symlink("boost", bpl_project_boost_inc)
 
         return (source_files,
                 {


### PR DESCRIPTION
Fixed install error on Windows 7 with Python 3.3 caused by:

```
symlink("boost", bpl_project_boost_inc)
```

OSError: symbolic link privilege not held
