### PR TITLE
FIX: make array.vec.make_xxx work for all sizes; remove default values

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -27,7 +27,8 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 """
 
-
+import warnings
+warnings.simplefilter('default')
 import numpy as np
 import pyopencl.elementwise as elementwise
 import pyopencl as cl
@@ -99,14 +100,29 @@ def _create_vector_types():
 
             setattr(vec, name, dtype)
 
-            my_field_names = ",".join(field_names[:count])
-            my_field_names_defaulted = ",".join(
-                    "%s=0" % fn for fn in field_names[:count])
-            setattr(vec, "make_"+name,
-                    staticmethod(eval(
-                        "lambda %s: array((%s), dtype=my_dtype)"
-                        % (my_field_names_defaulted, my_field_names),
-                        dict(array=np.array, my_dtype=dtype))))
+            def create_array(dtype, count, padded_count, *args, **kwargs):
+                if len(args) < count:
+                    warnings.warn("default values for make_xxx are deprecated;"+
+                            " instead specify all parameters or use"+
+                            " array.vec.zeros_xxx", DeprecationWarning)
+                padded_args = tuple(list(args)+[0]*(padded_count-len(args)))
+                array = eval("array(padded_args, dtype=dtype)",
+                        dict(array=np.array, padded_args=padded_args,
+                        dtype=dtype))
+                for key, val in kwargs.items():
+                    array[key] = val
+                return array
+
+            setattr(vec, "make_"+name, staticmethod(eval(
+                    "lambda *args, **kwargs: create_array(dtype, %i, %i, "+
+                    "*args, **kwargs)" % (count, padded_count),
+                    dict(create_array=create_array, dtype=dtype))))
+            setattr(vec, "filled_"+name, staticmethod(eval(
+                    "lambda val: vec.make_%s(*[val]*%i)" % (name, count))))
+            setattr(vec, "zeros_"+name,
+                    staticmethod(eval("lambda: vec.filled_%s(0)" % (name))))
+            setattr(vec, "ones_"+name,
+                    staticmethod(eval("lambda: vec.filled_%s(1)" % (name))))
 
             vec.types[np.dtype(base_type), count] = dtype
             vec.type_to_scalar_and_count[dtype] = np.dtype(base_type), count


### PR DESCRIPTION
...ires padding); deliberately removed default values (feel free to add again)

Closes #28

IMPORTANT: I didn't run the tests. Removing the default values might break some applications.

Rationale for removing the default values: It's just too easy to create the wrong vector size if all parameters have default values.
