### PR TITLE
FIX: no more explicit padding required for vectors

### DIFF
--- a/doc/array.rst
+++ b/doc/array.rst
@@ -29,6 +29,21 @@ Vector Types
     Python code. For each type, a `make_type` function is also provided (e.g.
     `make_float3(x,y,z)`).
 
+    If you want to construct a pre-initialized vector type you have three new
+    functions to choose from:
+
+        * `zeros_type()`
+        * `ones_type()`
+        * `filled_type(fill_value)`
+
+    .. versionadded:: 2013.3
+
+    .. versionchanged:: 2013.3
+        The `make_type` functions have a default value (0) for each component.
+        Relying on the default values has been deprecated. Either specify all
+        components or use one of th new flavors mentioned above for constructing
+        a vector.
+
 Custom data types
 ^^^^^^^^^^^^^^^^^
 

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -28,6 +28,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 """
 
 
+import warnings
 import numpy as np
 import pyopencl.elementwise as elementwise
 import pyopencl as cl
@@ -99,14 +100,29 @@ def _create_vector_types():
 
             setattr(vec, name, dtype)
 
-            my_field_names = ",".join(field_names[:count])
-            my_field_names_defaulted = ",".join(
-                    "%s=0" % fn for fn in field_names[:count])
-            setattr(vec, "make_"+name,
-                    staticmethod(eval(
-                        "lambda %s: array((%s), dtype=my_dtype)"
-                        % (my_field_names_defaulted, my_field_names),
-                        dict(array=np.array, my_dtype=dtype))))
+            def create_array(dtype, count, padded_count, *args, **kwargs):
+                if len(args) < count:
+                    warnings.warn("default values for make_xxx are deprecated;"+
+                            " instead specify all parameters or use"+
+                            " array.vec.zeros_xxx", DeprecationWarning)
+                padded_args = tuple(list(args)+[0]*(padded_count-len(args)))
+                array = eval("array(padded_args, dtype=dtype)",
+                        dict(array=np.array, padded_args=padded_args,
+                        dtype=dtype))
+                for key, val in kwargs.items():
+                    array[key] = val
+                return array
+
+            setattr(vec, "make_"+name, staticmethod(eval(
+                    "lambda *args, **kwargs: create_array(dtype, %i, %i, "+
+                    "*args, **kwargs)" % (count, padded_count),
+                    dict(create_array=create_array, dtype=dtype))))
+            setattr(vec, "filled_"+name, staticmethod(eval(
+                    "lambda val: vec.make_%s(*[val]*%i)" % (name, count))))
+            setattr(vec, "zeros_"+name,
+                    staticmethod(eval("lambda: vec.filled_%s(0)" % (name))))
+            setattr(vec, "ones_"+name,
+                    staticmethod(eval("lambda: vec.filled_%s(1)" % (name))))
 
             vec.types[np.dtype(base_type), count] = dtype
             vec.type_to_scalar_and_count[dtype] = np.dtype(base_type), count


### PR DESCRIPTION
Additionally, relying on default values for initialization triggers a
deprecation warning. Added three more vector constructors: filled_ which fills
the entire vector with a given value, zeros_ and ones_.

Closes #28

There is one glitch with keyword arguments: First I didn't allow keyword
arguments at all. This made it possible to check the number of arguments
and to correctly issue a deprecation warning. On the other hand, ignoring
keyword argument might break existing codes, so I added them back in.
Now the check for the correct number of parameters is not reliable any more,
because it's difficult to judge whether all vector components have been
addressed. 

What do you think? What's the future for keyword arguments anyway?
