### PR TITLE
Use the documented struct.calcsize to determine machine word size for better pypy support.

### DIFF
--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -42,13 +42,14 @@ from pyopencl.compyte.dtypes import (  # noqa
 
 def _register_types():
     from pyopencl.compyte.dtypes import _fill_dtype_registry
+    import struct
 
     _fill_dtype_registry(respect_windows=False, include_bool=False)
 
     get_or_register_dtype("cfloat_t", np.complex64)
     get_or_register_dtype("cdouble_t", np.complex128)
 
-    is_64_bit = tuple.__itemsize__ * 8 == 64
+    is_64_bit = struct.calcsize('@P') * 8 == 64
     if not is_64_bit:
         get_or_register_dtype(
                 ["unsigned long", "unsigned long int"], np.uint64)


### PR DESCRIPTION
See #36 and https://github.com/inducer/compyte/pull/20
`__itemsize__` is an undocumented cpython specific api that is not possible to support in pypy.
This patch fix the problem by using the documented `struct.calcsize` function to achieve the same purpose.
