### PR TITLE
Fix AttributeError: 'Win32Platform' object has no attribute 'GLX'

### DIFF
--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -419,18 +419,20 @@ def get_arg_offset_adjuster_code(arg_types):
 def get_gl_sharing_context_properties():
     ctx_props = cl.context_properties
 
-    from OpenGL import platform as gl_platform, GLX, WGL
+    from OpenGL import platform as gl_platform
 
     props = []
 
     import sys
     if sys.platform in ["linux", "linux2"]:
+        from OpenGL import GLX
         props.append(
             (ctx_props.GL_CONTEXT_KHR, gl_platform.GetCurrentContext()))
         props.append(
                 (ctx_props.GLX_DISPLAY_KHR,
                     GLX.glXGetCurrentDisplay()))
     elif sys.platform == "win32":
+        from OpenGL import WGL
         props.append(
             (ctx_props.GL_CONTEXT_KHR, gl_platform.GetCurrentContext()))
         props.append(


### PR DESCRIPTION
`gl_interop_demo.py` fails on Windows with PyOpenGL-3.1.0b3:

```
Traceback (most recent call last):
  File "gl_interop_demo.py", line 37, in initialize
    + get_gl_sharing_context_properties())
  File "X:\Python34\lib\site-packages\pyopencl\tools.py", line 423, in get_gl_sharing_context_properties
    from OpenGL import platform as gl_platform, GLX, WGL
  File "X:\Python34\lib\site-packages\OpenGL\GLX\__init__.py", line 3, in <module>
    from OpenGL.GLX.VERSION.GLX_1_0 import *
  File "X:\Python34\lib\site-packages\OpenGL\GLX\VERSION\GLX_1_0.py", line 14, in <module>
    from OpenGL.raw.GLX.VERSION.GLX_1_0 import *
  File "X:\Python34\lib\site-packages\OpenGL\raw\GLX\VERSION\GLX_1_0.py", line 43, in <module>
    @_p.types(ctypes.POINTER(_cs.XVisualInfo),ctypes.POINTER(_cs.Display),_cs.c_int,ctypes.POINTER(_cs.c_int))
  File "X:\Python34\lib\site-packages\OpenGL\raw\GLX\VERSION\GLX_1_0.py", line 13, in _f
    return _p.createFunction( function,_p.PLATFORM.GLX,'GLX_VERSION_GLX_1_0',error_checker=_errors._error_checker)
AttributeError: 'Win32Platform' object has no attribute 'GLX'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "gl_interop_demo.py", line 81, in <module>
    initialize()
  File "gl_interop_demo.py", line 41, in initialize
    + get_gl_sharing_context_properties(),
  File "X:\Python34\lib\site-packages\pyopencl\tools.py", line 423, in get_gl_sharing_context_properties
    from OpenGL import platform as gl_platform, GLX, WGL
  File "X:\Python34\lib\site-packages\OpenGL\GLX\__init__.py", line 3, in <module>
    from OpenGL.GLX.VERSION.GLX_1_0 import *
  File "X:\Python34\lib\site-packages\OpenGL\GLX\VERSION\GLX_1_0.py", line 14, in <module>
    from OpenGL.raw.GLX.VERSION.GLX_1_0 import *
  File "X:\Python34\lib\site-packages\OpenGL\raw\GLX\VERSION\GLX_1_0.py", line 43, in <module>
    @_p.types(ctypes.POINTER(_cs.XVisualInfo),ctypes.POINTER(_cs.Display),_cs.c_int,ctypes.POINTER(_cs.c_int))
  File "X:\Python34\lib\site-packages\OpenGL\raw\GLX\VERSION\GLX_1_0.py", line 13, in _f
    return _p.createFunction( function,_p.PLATFORM.GLX,'GLX_VERSION_GLX_1_0',error_checker=_errors._error_checker)
AttributeError: 'Win32Platform' object has no attribute 'GLX'
```
