### PR TITLE
Fix warning for `cl_khr_fp64` in OpenCL 1.2

### DIFF
--- a/contrib/fortran-to-opencl/translate.py
+++ b/contrib/fortran-to-opencl/translate.py
@@ -1344,7 +1344,9 @@ def f2cl(source, free_form=False, strict=True,
         import pyopencl as cl
         ctx = cl.create_some_context()
         cl.Program(ctx, """
+            #ifndef cl_khr_fp64
             #pragma OPENCL EXTENSION cl_khr_fp64: enable
+            #endif
             #include <pyopencl-complex.h>
             """).build()
     return str_mod

--- a/pyopencl/_cluda.py
+++ b/pyopencl/_cluda.py
@@ -50,7 +50,9 @@ CLUDA_PREAMBLE = """
 #define GDIM_2 get_num_groups(2)
 
 % if double_support:
+    #ifndef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64: enable
+    #endif
 % endif
 """
 

--- a/pyopencl/algorithm.py
+++ b/pyopencl/algorithm.py
@@ -558,7 +558,9 @@ class RadixSort(object):
 
 _LIST_BUILDER_TEMPLATE = Template("""//CL//
 % if double_support:
+    #ifndef cl_khr_fp64
     #pragma OPENCL EXTENSION cl_khr_fp64: enable
+    #endif
     #define PYOPENCL_DEFINE_CDOUBLE
 % endif
 

--- a/pyopencl/clrandom.py
+++ b/pyopencl/clrandom.py
@@ -167,7 +167,11 @@ class RanluxGenerator(object):
     def generate_settings_defines(self, include_double_pragma=True):
         lines = []
         if include_double_pragma and self.support_double:
-            lines.append("#pragma OPENCL EXTENSION cl_khr_fp64 : enable")
+            lines.append("""
+                #ifndef cl_khr_fp64
+                #pragma OPENCL EXTENSION cl_khr_fp64: enable
+                #endif
+                """)
 
         lines.append("#define RANLUXCL_LUX %d" % self.luxury)
 

--- a/pyopencl/reduction.py
+++ b/pyopencl/reduction.py
@@ -47,7 +47,9 @@ KERNEL = """//CL//
     #define REDUCE(a, b) (${reduce_expr})
 
     % if double_support:
+        #ifndef cl_khr_fp64
         #pragma OPENCL EXTENSION cl_khr_fp64: enable
+        #endif
         #define PYOPENCL_DEFINE_CDOUBLE
     % endif
 

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -505,8 +505,12 @@ class _CDeclList:
 
         if self.saw_double:
             result = (
-                    "#pragma OPENCL EXTENSION cl_khr_fp64: enable\n"
-                    "#define PYOPENCL_DEFINE_CDOUBLE\n"
+                    """
+                    #ifndef cl_khr_fp64
+                    #pragma OPENCL EXTENSION cl_khr_fp64: enable
+                    #endif
+                    #define PYOPENCL_DEFINE_CDOUBLE
+                    """
                     + result)
 
         return result


### PR DESCRIPTION
On Debian 7 with OpenCL 1.2 (`amd-libopencl1` from backports) I got the following warning each time I tried to use a PyOpenCL _ReductionKernel_. Adding a correct `#ifdef` solves the problem, this is why I added it everywhere.

```
$ PYOPENCL_CTX=0 PYOPENCL_COMPILER_OUTPUT=1 ./test_cl_array.py 
/.../venv/src/pyopencl/pyopencl/__init__.py:57: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'Intel(R) Core(TM) i5 CPU       M 560  @ 2.67GHz' on 'AMD Accelerated Parallel Processing' at 0x13ee130> succeeded, but said:

"/tmp/OCLpZ9ajX.cl", line 6: warning: OpenCL extension is now part of core
          #pragma OPENCL EXTENSION cl_khr_fp64: enable
                                   ^

  warn(text, CompilerWarning)
/.../venv/src/pyopencl/pyopencl/__init__.py:57: CompilerWarning: Built kernel retrieved from cache. Original from-source build had warnings:
Build on <pyopencl.Device 'Intel(R) Core(TM) i5 CPU       M 560  @ 2.67GHz' on 'AMD Accelerated Parallel Processing' at 0x13ee130> succeeded, but said:

"/tmp/OCLTQ0J0B.cl", line 6: warning: OpenCL extension is now part of core
          #pragma OPENCL EXTENSION cl_khr_fp64: enable
                                   ^

  warn(text, CompilerWarning)
```

Related links:
- http://www.khronos.org/message_boards/showthread.php/9054-cl_khr_fp64-becoming-an-quot-optional-core-feature-quot
- http://www.informit.com/articles/article.aspx?p=1732873&seqNum=13
