### PR TITLE
Add `out` parameter to ReductionKernel call.

### DIFF
--- a/doc/algorithm.rst
+++ b/doc/algorithm.rst
@@ -73,9 +73,8 @@ Sums and counts ("reduce")
 
     Vectors in *map_expr* should be indexed by the variable *i*. *reduce_expr*
     uses the formal values "a" and "b" to indicate two operands of a binary
-    reduction operation. If you do not specify a *map_expr*, "in[i]" -- and
-    therefore the presence of only one input argument -- is automatically
-    assumed.
+    reduction operation. If you do not specify a *map_expr*, ``in[i]`` is
+    automatically assumed and treated as the only one input argument.
 
     *dtype_out* specifies the :class:`numpy.dtype` in which the reduction is
     performed and in which the result is returned. *neutral* is specified as
@@ -86,9 +85,13 @@ Sums and counts ("reduce")
     :meth:`pyopencl.Program.build`. *preamble* specifies a string of code that
     is inserted before the actual kernels.
 
-    .. method:: __call__(*args, queue=None, wait_for=None, return_event=False)
+    .. method:: __call__(*args, queue=None, wait_for=None, return_event=False, out=None)
 
         |explain-waitfor|
+
+        With *out* the resulting single-entry :class:`pyopencl.array.Array` can
+        be specified. Because offsets are supported one can store results
+        anywhere (e.g. ``out=a[3]``).
 
         :return: the resulting scalar as a single-entry :class:`pyopencl.array.Array`
             if *return_event* is *False*, otherwise a tuple ``(scalar_array, event)``.


### PR DESCRIPTION
I was missing an option to specify the results location of a ReductionKernel call. Therefore I added it together with offset support for the `out` parameter.

Consequently it is now possible to do e.g. per-row reductions of a 2D array:

``` python
a_g = cl.array.to_device(queue, a_np)
print a_g

res_g = cl.array.empty(queue, (a_g.shape[0],), a_np.dtype)
for i in range(a_g.shape[0]):
    prg(a_g[i], out=res_g[i])
print res_g
```

Outputs:

```
[[ 1.  1.  1.  1.  1.]
 [ 0.  4.  0.  0.  0.]
 [ 1.  1.  1.  8.  1.]]
[  5.   4.  12.]
```
