### PR TITLE
Fix cl_load_edit_kernel with build options

### DIFF
--- a/pyopencl/ipython_ext.py
+++ b/pyopencl/ipython_ext.py
@@ -71,7 +71,7 @@ class PyOpenCLMagics(Magics):
         header = "%%cl_kernel"
 
         if build_options:
-            header = "%s %s" % (header, build_options)
+            header = '%s -o "%s"' % (header, build_options)
 
         content = "%s\n\n%s" % (header, kernel)
 


### PR DESCRIPTION
Fix to `cl_load_edit_kernel` to  correctly set option argument.
