### PR TITLE
remove dtype hash hack since it is fixed in pypy

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -38,7 +38,6 @@ from pyopencl.compyte.array import (
         c_contiguous_strides as _c_contiguous_strides,
         ArrayFlags as _ArrayFlags,
         get_common_dtype as _get_common_dtype_base)
-from pyopencl.compyte.dtypes import DTypeDict as _DTypeDict
 from pyopencl.characterize import has_double_support
 
 
@@ -70,7 +69,7 @@ def _create_vector_types():
     from pyopencl.tools import get_or_register_dtype
 
     vec.types = {}
-    vec.type_to_scalar_and_count = _DTypeDict()
+    vec.type_to_scalar_and_count = {}
 
     counts = [2, 3, 4, 8, 16]
 

--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -37,9 +37,7 @@ import re
 
 from pyopencl.compyte.dtypes import (  # noqa
         get_or_register_dtype, TypeNameNotKnown,
-        register_dtype, dtype_to_ctype,
-        dtype_hashable as _dtype_hashable,
-        dtype_to_key as _dtype_to_key)
+        register_dtype, dtype_to_ctype)
 
 
 def _register_types():
@@ -515,16 +513,8 @@ class _CDeclList:
 
         return result
 
-if _dtype_hashable:
-    _memoize_match_dtype_to_c_struct = memoize
-else:
-    import json as _json
-    _memoize_match_dtype_to_c_struct = memoize(
-        key=lambda device, name, dtype, context=None:
-        (device, name, _dtype_to_key(dtype), context))
 
-
-@_memoize_match_dtype_to_c_struct
+@memoize
 def match_dtype_to_c_struct(device, name, dtype, context=None):
     """Return a tuple `(dtype, c_decl)` such that the C struct declaration
     in `c_decl` and the structure :class:`numpy.dtype` instance `dtype`
@@ -672,15 +662,8 @@ def match_dtype_to_c_struct(device, name, dtype, context=None):
 
     return dtype, c_decl
 
-if _dtype_hashable:
-    _memoize_dtype_to_c_struct = memoize
-else:
-    import json as _json  # noqa
-    _memoize_dtype_to_c_struct = memoize(
-        key=lambda device, dtype: (device, _dtype_to_key(dtype)))
 
-
-@_memoize_dtype_to_c_struct
+@memoize
 def dtype_to_c_struct(device, dtype):
     matched_dtype, c_decl = match_dtype_to_c_struct(
             device, dtype_to_ctype(dtype), dtype)


### PR DESCRIPTION
PyPy 2.4 is just released with the fix of the dtype hashing problem included.
