### PR TITLE
Use appdirs module to get appropriate cache directory.

### DIFF
--- a/pyopencl/cache.py
+++ b/pyopencl/cache.py
@@ -337,16 +337,15 @@ def _create_built_program_from_source_cached(ctx, src, options, devices, cache_d
             option_idx += 1
 
     if cache_dir is None:
-        from tempfile import gettempdir
-        import getpass
-        cache_dir = join(gettempdir(),
-                "pyopencl-compiler-cache-v2-uid%s-py%s" % (
-                    getpass.getuser(), ".".join(str(i) for i in sys.version_info)))
+        import appdirs
+        cache_dir = join(appdirs.user_cache_dir("pyopencl", "pyopencl"),
+                "pyopencl-compiler-cache-v2-py%s" % (
+                    ".".join(str(i) for i in sys.version_info),))
 
     # {{{ ensure cache directory exists
 
     try:
-        os.mkdir(cache_dir)
+        os.makedirs(cache_dir)
     except OSError, e:
         from errno import EEXIST
         if e.errno != EEXIST:

--- a/setup.py
+++ b/setup.py
@@ -208,6 +208,7 @@ def main():
                 "pytools>=2014.2",
                 "pytest>=2",
                 "decorator>=3.2.0",
+                "appdirs>=1.4.0",
                 # "Mako>=0.3.6",
                 ],
 


### PR DESCRIPTION
This fixes an insecure temporary file creation bug on UNIX-like systems.
