### PR TITLE
Fixes an issue where pre-providing an answer on a machine with only one platform will throw a RuntimeError.

### DIFF
--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -818,8 +818,6 @@ def create_some_context(interactive=None, answers=None):
 
     if not platforms:
         raise Error("no platforms found")
-    elif len(platforms) == 1:
-        platform, = platforms
     else:
         if not answers:
             cc_print("Choose platform:")


### PR DESCRIPTION
If an answer is given for a machine with only one platform, nothing is popped from the `answers` array. As a result, the final check in `create_some_context` fails with a runtime error.

Using the behaviour of the approach with many platforms will not only remove the choice from the `answers` array, but it will ensure that the platform chosen is indeed the intended choice.