### PR TITLE
Work around in setup.py for use of numpy during build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: latin-1 -*-
+from setuptools.command.build_ext import build_ext as _build_ext
+
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
 
 def get_config_schema():
@@ -205,6 +214,7 @@ def main():
                 ],
 
             install_requires=[
+		"numpy",
                 "pytools>=2014.2",
                 "pytest>=2",
                 "decorator>=3.2.0",


### PR DESCRIPTION
Currently when installing via pip (pip install pyopencl) build fails because numpy cannot be imported. This seems to be a known issue with the way numpy installation is organised (see http://stackoverflow.com/questions/19919905/how-to-bootstrap-numpy-installation-in-setup-py). The workaround used in this link is to force numpy visibility using "\_\_builtins\_\_.\_\_NUMPY_SETUP\_\_ = False".

I have added this to setup.py, as well as adding numpy to install_requires since it is used when running pyopencl. Tested with "pip install -e <path to modified source>".