### PR TITLE
fix shebang on configure.py

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1,5 +1,6 @@
-from __future__ import absolute_import
 #! /usr/bin/env python
+
+from __future__ import absolute_import
 
 from aksetup_helper import configure_frontend
 configure_frontend()


### PR DESCRIPTION
6e24507b91f5f27c8f0443ba3d6ff1e307d30a87 broke the shebang on `configure.py`. I must admit that the error message for this was quite asuming:

```
from: can't read /var/mail/__future__
```

... but I decided to fix it anyway.