### PR TITLE
Fix build on Ubuntu/GCC 4.8.4 and 4.9.0

### DIFF
--- a/src/c_wrapper/buffer.cpp
+++ b/src/c_wrapper/buffer.cpp
@@ -18,7 +18,7 @@ buffer::get_sub_region(size_t orig, size_t size, cl_mem_flags flags) const
     cl_buffer_region reg = {orig, size};
 
     auto mem = retry_mem_error([&] {
-            return pyopencl_call_guarded(clCreateSubBuffer, this, flags,
+            return pyopencl_call_guarded(clCreateSubBuffer, data(), flags,
                                          CL_BUFFER_CREATE_TYPE_REGION, &reg);
         });
     return new_buffer(mem);
@@ -28,7 +28,7 @@ PYOPENCL_USE_RESULT buffer*
 buffer::getitem(ssize_t start, ssize_t end) const
 {
     ssize_t length;
-    pyopencl_call_guarded(clGetMemObjectInfo, this, CL_MEM_SIZE,
+    pyopencl_call_guarded(clGetMemObjectInfo, data(), CL_MEM_SIZE,
                           size_arg(length), nullptr);
     if (PYOPENCL_UNLIKELY(length <= 0))
         throw clerror("Buffer.__getitem__", CL_INVALID_VALUE,
@@ -45,7 +45,7 @@ buffer::getitem(ssize_t start, ssize_t end) const
         throw clerror("Buffer.__getitem__", CL_INVALID_VALUE,
                       "Buffer slice should have end > start >= 0");
     cl_mem_flags flags;
-    pyopencl_call_guarded(clGetMemObjectInfo, this, CL_MEM_FLAGS,
+    pyopencl_call_guarded(clGetMemObjectInfo, data(), CL_MEM_FLAGS,
                           size_arg(flags), nullptr);
     flags &= ~CL_MEM_COPY_HOST_PTR;
     return get_sub_region((size_t)start, (size_t)(end - start), flags);

--- a/src/c_wrapper/command_queue.cpp
+++ b/src/c_wrapper/command_queue.cpp
@@ -13,7 +13,7 @@ template void print_buf<cl_command_queue>(
 
 command_queue::~command_queue()
 {
-    pyopencl_call_guarded_cleanup(clReleaseCommandQueue, this);
+    pyopencl_call_guarded_cleanup(clReleaseCommandQueue, data());
 }
 
 generic_info
@@ -22,15 +22,15 @@ command_queue::get_info(cl_uint param_name) const
     switch ((cl_command_queue_info)param_name) {
     case CL_QUEUE_CONTEXT:
         return pyopencl_get_opaque_info(context, CommandQueue,
-                                        this, param_name);
+                                        data(), param_name);
     case CL_QUEUE_DEVICE:
-        return pyopencl_get_opaque_info(device, CommandQueue, this, param_name);
+        return pyopencl_get_opaque_info(device, CommandQueue, data(), param_name);
     case CL_QUEUE_REFERENCE_COUNT:
         return pyopencl_get_int_info(cl_uint, CommandQueue,
-                                     this, param_name);
+                                     data(), param_name);
     case CL_QUEUE_PROPERTIES:
         return pyopencl_get_int_info(cl_command_queue_properties,
-                                     CommandQueue, this, param_name);
+                                     CommandQueue, data(), param_name);
     default:
         throw clerror("CommandQueue.get_info", CL_INVALID_VALUE);
     }

--- a/src/c_wrapper/command_queue.h
+++ b/src/c_wrapper/command_queue.h
@@ -19,7 +19,7 @@ public:
         : clobj(q)
     {
         if (retain) {
-            pyopencl_call_guarded(clRetainCommandQueue, this);
+            pyopencl_call_guarded(clRetainCommandQueue, data());
         }
     }
     PYOPENCL_INLINE

--- a/src/c_wrapper/context.cpp
+++ b/src/c_wrapper/context.cpp
@@ -33,7 +33,7 @@ context::get_version(cl_context ctx, int *major, int *minor)
 
 context::~context()
 {
-    pyopencl_call_guarded_cleanup(clReleaseContext, this);
+    pyopencl_call_guarded_cleanup(clReleaseContext, data());
 }
 
 generic_info
@@ -42,13 +42,13 @@ context::get_info(cl_uint param_name) const
     switch ((cl_context_info)param_name) {
     case CL_CONTEXT_REFERENCE_COUNT:
         return pyopencl_get_int_info(cl_uint, Context,
-                                     this, param_name);
+                                     data(), param_name);
     case CL_CONTEXT_DEVICES:
         return pyopencl_get_opaque_array_info(device, Context,
-                                              this, param_name);
+                                              data(), param_name);
     case CL_CONTEXT_PROPERTIES: {
         auto result = pyopencl_get_vec_info(
-            cl_context_properties, Context, this, param_name);
+            cl_context_properties, Context, data(), param_name);
         pyopencl_buf<generic_info> py_result(result.len() / 2);
         size_t i = 0;
         for (;i < py_result.len();i++) {
@@ -96,7 +96,7 @@ context::get_info(cl_uint param_name) const
 #if PYOPENCL_CL_VERSION >= 0x1010
     case CL_CONTEXT_NUM_DEVICES:
         return pyopencl_get_int_info(cl_uint, Context,
-                                     this, param_name);
+                                     data(), param_name);
 #endif
 
     default:

--- a/src/c_wrapper/context.h
+++ b/src/c_wrapper/context.h
@@ -20,7 +20,7 @@ public:
         : clobj(ctx)
     {
         if (retain) {
-            pyopencl_call_guarded(clRetainContext, this);
+            pyopencl_call_guarded(clRetainContext, data());
         }
     }
     ~context();

--- a/src/c_wrapper/device.cpp
+++ b/src/c_wrapper/device.cpp
@@ -25,16 +25,16 @@ device::~device()
     else if (m_ref_type == REF_FISSION_EXT) {
 #if PYOPENCL_CL_VERSION >= 0x1020
         cl_platform_id plat;
-        pyopencl_call_guarded_cleanup(clGetDeviceInfo, this, CL_DEVICE_PLATFORM,
+        pyopencl_call_guarded_cleanup(clGetDeviceInfo, data(), CL_DEVICE_PLATFORM,
                                       size_arg(plat), nullptr);
 #endif
         pyopencl_call_guarded_cleanup(
-            pyopencl_get_ext_fun(plat, clReleaseDeviceEXT), this);
+            pyopencl_get_ext_fun(plat, clReleaseDeviceEXT), data());
     }
 #endif
 #if PYOPENCL_CL_VERSION >= 0x1020
     else if (m_ref_type == REF_CL_1_2) {
-        pyopencl_call_guarded_cleanup(clReleaseDevice, this);
+        pyopencl_call_guarded_cleanup(clReleaseDevice, data());
     }
 #endif
 }
@@ -43,7 +43,7 @@ generic_info
 device::get_info(cl_uint param_name) const
 {
 #define DEV_GET_INT_INF(TYPE)                                   \
-    pyopencl_get_int_info(TYPE, Device, this, param_name)
+    pyopencl_get_int_info(TYPE, Device, data(), param_name)
 
     switch ((cl_device_info)param_name) {
     case CL_DEVICE_TYPE:
@@ -56,7 +56,7 @@ device::get_info(cl_uint param_name) const
         return DEV_GET_INT_INF(cl_uint);
 
     case CL_DEVICE_MAX_WORK_ITEM_SIZES:
-        return pyopencl_get_array_info(size_t, Device, this, param_name);
+        return pyopencl_get_array_info(size_t, Device, data(), param_name);
 
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_CHAR:
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_SHORT:
@@ -128,10 +128,10 @@ device::get_info(cl_uint param_name) const
     case CL_DEVICE_PROFILE:
     case CL_DEVICE_VERSION:
     case CL_DEVICE_EXTENSIONS:
-        return pyopencl_get_str_info(Device, this, param_name);
+        return pyopencl_get_str_info(Device, data(), param_name);
 
     case CL_DEVICE_PLATFORM:
-        return pyopencl_get_opaque_info(platform, Device, this, param_name);
+        return pyopencl_get_opaque_info(platform, Device, data(), param_name);
 #if PYOPENCL_CL_VERSION >= 0x1010
     case CL_DEVICE_PREFERRED_VECTOR_WIDTH_HALF:
     case CL_DEVICE_NATIVE_VECTOR_WIDTH_CHAR:
@@ -146,7 +146,7 @@ device::get_info(cl_uint param_name) const
     case CL_DEVICE_HOST_UNIFIED_MEMORY:
         return DEV_GET_INT_INF(cl_bool);
     case CL_DEVICE_OPENCL_C_VERSION:
-        return pyopencl_get_str_info(Device, this, param_name);
+        return pyopencl_get_str_info(Device, data(), param_name);
 #endif
 #ifdef CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV
     case CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV:
@@ -161,12 +161,12 @@ device::get_info(cl_uint param_name) const
 #endif
 #if defined(cl_ext_device_fission) && defined(PYOPENCL_USE_DEVICE_FISSION)
     case CL_DEVICE_PARENT_DEVICE_EXT:
-        return pyopencl_get_opaque_info(device, Device, this, param_name);
+        return pyopencl_get_opaque_info(device, Device, data(), param_name);
     case CL_DEVICE_PARTITION_TYPES_EXT:
     case CL_DEVICE_AFFINITY_DOMAINS_EXT:
     case CL_DEVICE_PARTITION_STYLE_EXT:
         return pyopencl_get_array_info(cl_device_partition_property_ext,
-                                       Device, this, param_name);
+                                       Device, data(), param_name);
     case CL_DEVICE_REFERENCE_COUNT_EXT:
         return DEV_GET_INT_INF(cl_uint);
 #endif
@@ -174,21 +174,21 @@ device::get_info(cl_uint param_name) const
     case CL_DEVICE_LINKER_AVAILABLE:
         return DEV_GET_INT_INF(cl_bool);
     case CL_DEVICE_BUILT_IN_KERNELS:
-        return pyopencl_get_str_info(Device, this, param_name);
+        return pyopencl_get_str_info(Device, data(), param_name);
     case CL_DEVICE_IMAGE_MAX_BUFFER_SIZE:
     case CL_DEVICE_IMAGE_MAX_ARRAY_SIZE:
         return DEV_GET_INT_INF(size_t);
     case CL_DEVICE_PARENT_DEVICE:
-        return pyopencl_get_opaque_info(device, Device, this, param_name);
+        return pyopencl_get_opaque_info(device, Device, data(), param_name);
     case CL_DEVICE_PARTITION_MAX_SUB_DEVICES:
         return DEV_GET_INT_INF(cl_uint);
     case CL_DEVICE_PARTITION_TYPE:
     case CL_DEVICE_PARTITION_PROPERTIES:
         return pyopencl_get_array_info(cl_device_partition_property,
-                                       Device, this, param_name);
+                                       Device, data(), param_name);
     case CL_DEVICE_PARTITION_AFFINITY_DOMAIN:
         return pyopencl_get_array_info(cl_device_affinity_domain,
-                                       Device, this, param_name);
+                                       Device, data(), param_name);
     case CL_DEVICE_REFERENCE_COUNT:
         return DEV_GET_INT_INF(cl_uint);
     case CL_DEVICE_PREFERRED_INTEROP_USER_SYNC:
@@ -210,12 +210,12 @@ device::get_info(cl_uint param_name) const
         */
 #ifdef CL_DEVICE_BOARD_NAME_AMD
     case CL_DEVICE_BOARD_NAME_AMD: ;
-        return pyopencl_get_str_info(Device, this, param_name);
+        return pyopencl_get_str_info(Device, data(), param_name);
 #endif
 #ifdef CL_DEVICE_GLOBAL_FREE_MEMORY_AMD
     case CL_DEVICE_GLOBAL_FREE_MEMORY_AMD:
         return pyopencl_get_array_info(size_t, Device,
-                                       this, param_name);
+                                       data(), param_name);
 #endif
 #ifdef CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD
     case CL_DEVICE_SIMD_PER_COMPUTE_UNIT_AMD:
@@ -262,10 +262,10 @@ device::create_sub_devices(const cl_device_partition_property *props)
 {
     // TODO debug print props
     cl_uint num_devices;
-    pyopencl_call_guarded(clCreateSubDevices, this, props, 0, nullptr,
+    pyopencl_call_guarded(clCreateSubDevices, data(), props, 0, nullptr,
                           buf_arg(num_devices));
     pyopencl_buf<cl_device_id> devices(num_devices);
-    pyopencl_call_guarded(clCreateSubDevices, this, props, devices,
+    pyopencl_call_guarded(clCreateSubDevices, data(), props, devices,
                           buf_arg(num_devices));
     return buf_to_base<device>(devices, true, device::REF_CL_1_2);
 }
@@ -276,7 +276,7 @@ device::create_sub_devices_ext(const cl_device_partition_property_ext *props)
 {
 #if PYOPENCL_CL_VERSION >= 0x1020
     cl_platform_id plat;
-    pyopencl_call_guarded(clGetDeviceInfo, this, CL_DEVICE_PLATFORM,
+    pyopencl_call_guarded(clGetDeviceInfo, data(), CL_DEVICE_PLATFORM,
                           size_arg(plat), nullptr);
 #endif
     auto clCreateSubDevicesEXT =
@@ -284,10 +284,10 @@ device::create_sub_devices_ext(const cl_device_partition_property_ext *props)
 
     // TODO debug print props
     cl_uint num_devices;
-    pyopencl_call_guarded(clCreateSubDevicesEXT, this, props, 0, nullptr,
+    pyopencl_call_guarded(clCreateSubDevicesEXT, data(), props, 0, nullptr,
                           buf_arg(num_devices));
     pyopencl_buf<cl_device_id> devices(num_devices);
-    pyopencl_call_guarded(clCreateSubDevicesEXT, this, props, devices,
+    pyopencl_call_guarded(clCreateSubDevicesEXT, data(), props, devices,
                           buf_arg(num_devices));
     return buf_to_base<device>(devices, true, device::REF_FISSION_EXT);
 }

--- a/src/c_wrapper/device.h
+++ b/src/c_wrapper/device.h
@@ -36,17 +36,17 @@ public:
             else if (ref_type == REF_FISSION_EXT) {
 #if PYOPENCL_CL_VERSION >= 0x1020
                 cl_platform_id plat;
-                pyopencl_call_guarded(clGetDeviceInfo, this,
+                pyopencl_call_guarded(clGetDeviceInfo, data(),
                                       CL_DEVICE_PLATFORM, size_arg(plat),
                                       nullptr);
 #endif
                 pyopencl_call_guarded(
-                    pyopencl_get_ext_fun(plat, clRetainDeviceEXT), this);
+                    pyopencl_get_ext_fun(plat, clRetainDeviceEXT), data());
             }
 #endif
 #if PYOPENCL_CL_VERSION >= 0x1020
             else if (ref_type == REF_CL_1_2) {
-                pyopencl_call_guarded(clRetainDevice, this);
+                pyopencl_call_guarded(clRetainDevice, data());
             }
 #endif
 

--- a/src/c_wrapper/event.cpp
+++ b/src/c_wrapper/event.cpp
@@ -40,7 +40,7 @@ event::event(cl_event event, bool retain, event_private *p)
 {
     if (retain) {
         try {
-            pyopencl_call_guarded(clRetainEvent, this);
+            pyopencl_call_guarded(clRetainEvent, data());
         } catch (...) {
             m_p->call_finish();
             delete m_p;
@@ -106,7 +106,7 @@ event::release_private() noexcept
 event::~event()
 {
     release_private();
-    pyopencl_call_guarded_cleanup(clReleaseEvent, this);
+    pyopencl_call_guarded_cleanup(clReleaseEvent, data());
 }
 
 generic_info
@@ -114,17 +114,17 @@ event::get_info(cl_uint param_name) const
 {
     switch ((cl_event_info)param_name) {
     case CL_EVENT_COMMAND_QUEUE:
-        return pyopencl_get_opaque_info(command_queue, Event, this, param_name);
+        return pyopencl_get_opaque_info(command_queue, Event, data(), param_name);
     case CL_EVENT_COMMAND_TYPE:
         return pyopencl_get_int_info(cl_command_type, Event,
-                                     this, param_name);
+                                     data(), param_name);
     case CL_EVENT_COMMAND_EXECUTION_STATUS:
-        return pyopencl_get_int_info(cl_int, Event, this, param_name);
+        return pyopencl_get_int_info(cl_int, Event, data(), param_name);
     case CL_EVENT_REFERENCE_COUNT:
-        return pyopencl_get_int_info(cl_uint, Event, this, param_name);
+        return pyopencl_get_int_info(cl_uint, Event, data(), param_name);
 #if PYOPENCL_CL_VERSION >= 0x1010
     case CL_EVENT_CONTEXT:
-        return pyopencl_get_opaque_info(context, Event, this, param_name);
+        return pyopencl_get_opaque_info(context, Event, data(), param_name);
 #endif
 
     default:
@@ -140,7 +140,7 @@ event::get_profiling_info(cl_profiling_info param) const
     case CL_PROFILING_COMMAND_SUBMIT:
     case CL_PROFILING_COMMAND_START:
     case CL_PROFILING_COMMAND_END:
-        return pyopencl_get_int_info(cl_ulong, EventProfiling, this, param);
+        return pyopencl_get_int_info(cl_ulong, EventProfiling, data(), param);
     default:
         throw clerror("Event.get_profiling_info", CL_INVALID_VALUE);
     }
@@ -195,7 +195,7 @@ public:
     PYOPENCL_INLINE void
     set_status(cl_int status)
     {
-        pyopencl_call_guarded(clSetUserEventStatus, this, status);
+        pyopencl_call_guarded(clSetUserEventStatus, data(), status);
     }
 };
 #endif

--- a/src/c_wrapper/event.h
+++ b/src/c_wrapper/event.h
@@ -39,7 +39,7 @@ public:
         auto func = new rm_ref_t<Func>(std::forward<Func>(_func));
         try {
             pyopencl_call_guarded(
-                clSetEventCallback, this, type,
+                clSetEventCallback, data(), type,
                 [] (cl_event, cl_int status, void *data) {
                     rm_ref_t<Func> *func = static_cast<rm_ref_t<Func>*>(data);
                     std::thread t([func, status] () {

--- a/src/c_wrapper/image.cpp
+++ b/src/c_wrapper/image.cpp
@@ -17,7 +17,7 @@ image::get_image_info(cl_image_info param) const
 {
     switch (param) {
     case CL_IMAGE_FORMAT:
-        return pyopencl_get_int_info(cl_image_format, Image, this, param);
+        return pyopencl_get_int_info(cl_image_format, Image, data(), param);
     case CL_IMAGE_ELEMENT_SIZE:
     case CL_IMAGE_ROW_PITCH:
     case CL_IMAGE_SLICE_PITCH:
@@ -27,7 +27,7 @@ image::get_image_info(cl_image_info param) const
 #if PYOPENCL_CL_VERSION >= 0x1020
     case CL_IMAGE_ARRAY_SIZE:
 #endif
-        return pyopencl_get_int_info(size_t, Image, this, param);
+        return pyopencl_get_int_info(size_t, Image, data(), param);
 
 #if PYOPENCL_CL_VERSION >= 0x1020
         // TODO:
@@ -44,7 +44,7 @@ image::get_image_info(cl_image_info param) const
         //      }
     case CL_IMAGE_NUM_MIP_LEVELS:
     case CL_IMAGE_NUM_SAMPLES:
-        return pyopencl_get_int_info(cl_uint, Image, this, param);
+        return pyopencl_get_int_info(cl_uint, Image, data(), param);
 #endif
     default:
         throw clerror("Image.get_image_info", CL_INVALID_VALUE);

--- a/src/c_wrapper/image.h
+++ b/src/c_wrapper/image.h
@@ -19,7 +19,7 @@ public:
     format()
     {
         if (!m_format.image_channel_data_type) {
-            pyopencl_call_guarded(clGetImageInfo, this, CL_IMAGE_FORMAT,
+            pyopencl_call_guarded(clGetImageInfo, data(), CL_IMAGE_FORMAT,
                                   size_arg(m_format), nullptr);
         }
         return m_format;

--- a/src/c_wrapper/kernel.cpp
+++ b/src/c_wrapper/kernel.cpp
@@ -16,7 +16,7 @@ template void print_buf<cl_kernel>(std::ostream&, const cl_kernel*,
 
 kernel::~kernel()
 {
-    pyopencl_call_guarded_cleanup(clReleaseKernel, this);
+    pyopencl_call_guarded_cleanup(clReleaseKernel, data());
 }
 
 generic_info
@@ -24,17 +24,17 @@ kernel::get_info(cl_uint param) const
 {
     switch ((cl_kernel_info)param) {
     case CL_KERNEL_FUNCTION_NAME:
-        return pyopencl_get_str_info(Kernel, this, param);
+        return pyopencl_get_str_info(Kernel, data(), param);
     case CL_KERNEL_NUM_ARGS:
     case CL_KERNEL_REFERENCE_COUNT:
-        return pyopencl_get_int_info(cl_uint, Kernel, this, param);
+        return pyopencl_get_int_info(cl_uint, Kernel, data(), param);
     case CL_KERNEL_CONTEXT:
-        return pyopencl_get_opaque_info(context, Kernel, this, param);
+        return pyopencl_get_opaque_info(context, Kernel, data(), param);
     case CL_KERNEL_PROGRAM:
-        return pyopencl_get_opaque_info(program, Kernel, this, param);
+        return pyopencl_get_opaque_info(program, Kernel, data(), param);
 #if PYOPENCL_CL_VERSION >= 0x1020
     case CL_KERNEL_ATTRIBUTES:
-        return pyopencl_get_str_info(Kernel, this, param);
+        return pyopencl_get_str_info(Kernel, data(), param);
 #endif
     default:
         throw clerror("Kernel.get_info", CL_INVALID_VALUE);
@@ -50,16 +50,16 @@ kernel::get_work_group_info(cl_kernel_work_group_info param,
     case CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE:
 #endif
     case CL_KERNEL_WORK_GROUP_SIZE:
-        return pyopencl_get_int_info(size_t, KernelWorkGroup, this, dev, param);
+        return pyopencl_get_int_info(size_t, KernelWorkGroup, data(), dev, param);
     case CL_KERNEL_COMPILE_WORK_GROUP_SIZE:
         return pyopencl_get_array_info(size_t, KernelWorkGroup,
-                                       this, dev, param);
+                                       data(), dev, param);
     case CL_KERNEL_LOCAL_MEM_SIZE:
 #if PYOPENCL_CL_VERSION >= 0x1010
     case CL_KERNEL_PRIVATE_MEM_SIZE:
 #endif
         return pyopencl_get_int_info(cl_ulong, KernelWorkGroup,
-                                     this, dev, param);
+                                     data(), dev, param);
     default:
         throw clerror("Kernel.get_work_group_info", CL_INVALID_VALUE);
     }
@@ -72,13 +72,13 @@ kernel::get_arg_info(cl_uint idx, cl_kernel_arg_info param) const
     switch (param) {
     case CL_KERNEL_ARG_ADDRESS_QUALIFIER:
         return pyopencl_get_int_info(cl_kernel_arg_address_qualifier,
-                                     KernelArg, this, idx, param);
+                                     KernelArg, data(), idx, param);
     case CL_KERNEL_ARG_ACCESS_QUALIFIER:
         return pyopencl_get_int_info(cl_kernel_arg_access_qualifier,
-                                     KernelArg, this, idx, param);
+                                     KernelArg, data(), idx, param);
     case CL_KERNEL_ARG_TYPE_NAME:
     case CL_KERNEL_ARG_NAME:
-        return pyopencl_get_str_info(KernelArg, this, idx, param);
+        return pyopencl_get_str_info(KernelArg, data(), idx, param);
     default:
         throw clerror("Kernel.get_arg_info", CL_INVALID_VALUE);
     }

--- a/src/c_wrapper/kernel.h
+++ b/src/c_wrapper/kernel.h
@@ -21,7 +21,7 @@ public:
         : clobj(knl)
     {
         if (retain) {
-            pyopencl_call_guarded(clRetainKernel, this);
+            pyopencl_call_guarded(clRetainKernel, data());
         }
     }
     ~kernel();

--- a/src/c_wrapper/memory_map.cpp
+++ b/src/c_wrapper/memory_map.cpp
@@ -14,7 +14,7 @@ memory_map::~memory_map()
     if (!m_valid.exchange(false))
         return;
     pyopencl_call_guarded_cleanup(clEnqueueUnmapMemObject, m_queue,
-                                  m_mem, this, 0, nullptr, nullptr);
+                                  m_mem, data(), 0, nullptr, nullptr);
 }
 
 void
@@ -28,7 +28,7 @@ memory_map::release(clobj_t *evt, const command_queue *queue,
     const auto wait_for = buf_from_class<event>(_wait_for, num_wait_for);
     queue = queue ? queue : &m_queue;
     pyopencl_call_guarded(clEnqueueUnmapMemObject, queue,
-                          m_mem, this, wait_for, event_out(evt));
+                          m_mem, data(), wait_for, event_out(evt));
 }
 
 generic_info

--- a/src/c_wrapper/memory_object.cpp
+++ b/src/c_wrapper/memory_object.cpp
@@ -15,12 +15,12 @@ memory_object::get_info(cl_uint param_name) const
     switch ((cl_mem_info)param_name) {
     case CL_MEM_TYPE:
         return pyopencl_get_int_info(cl_mem_object_type, MemObject,
-                                     this, param_name);
+                                     data(), param_name);
     case CL_MEM_FLAGS:
         return pyopencl_get_int_info(cl_mem_flags, MemObject,
-                                     this, param_name);
+                                     data(), param_name);
     case CL_MEM_SIZE:
-        return pyopencl_get_int_info(size_t, MemObject, this, param_name);
+        return pyopencl_get_int_info(size_t, MemObject, data(), param_name);
     case CL_MEM_HOST_PTR:
         throw clerror("MemoryObject.get_info", CL_INVALID_VALUE,
                       "Use MemoryObject.get_host_array to get "
@@ -28,9 +28,9 @@ memory_object::get_info(cl_uint param_name) const
     case CL_MEM_MAP_COUNT:
     case CL_MEM_REFERENCE_COUNT:
         return pyopencl_get_int_info(cl_uint, MemObject,
-                                     this, param_name);
+                                     data(), param_name);
     case CL_MEM_CONTEXT:
-        return pyopencl_get_opaque_info(context, MemObject, this, param_name);
+        return pyopencl_get_opaque_info(context, MemObject, data(), param_name);
 
 #if PYOPENCL_CL_VERSION >= 0x1010
         // TODO
@@ -47,7 +47,7 @@ memory_object::get_info(cl_uint param_name) const
         //        return create_mem_object_wrapper(param_value);
         //      }
     case CL_MEM_OFFSET:
-        return pyopencl_get_int_info(size_t, MemObject, this, param_name);
+        return pyopencl_get_int_info(size_t, MemObject, data(), param_name);
 #endif
 
     default:
@@ -59,7 +59,7 @@ memory_object::~memory_object()
 {
     if (!m_valid.exchange(false))
         return;
-    pyopencl_call_guarded_cleanup(clReleaseMemObject, this);
+    pyopencl_call_guarded_cleanup(clReleaseMemObject, data());
 }
 
 // c wrapper

--- a/src/c_wrapper/memory_object.h
+++ b/src/c_wrapper/memory_object.h
@@ -21,7 +21,7 @@ public:
         : clobj(mem), m_valid(true)
     {
         if (retain) {
-            pyopencl_call_guarded(clRetainMemObject, this);
+            pyopencl_call_guarded(clRetainMemObject, data());
         }
     }
     PYOPENCL_INLINE
@@ -37,7 +37,7 @@ public:
             throw clerror("MemoryObject.release", CL_INVALID_VALUE,
                           "trying to double-unref mem object");
         }
-        pyopencl_call_guarded(clReleaseMemObject, this);
+        pyopencl_call_guarded(clReleaseMemObject, data());
     }
 #if 0
     PYOPENCL_USE_RESULT size_t

--- a/src/c_wrapper/platform.cpp
+++ b/src/c_wrapper/platform.cpp
@@ -23,7 +23,7 @@ platform::get_info(cl_uint param_name) const
 #if !(defined(CL_PLATFORM_NVIDIA) && CL_PLATFORM_NVIDIA == 0x3001)
     case CL_PLATFORM_EXTENSIONS:
 #endif
-        return pyopencl_get_str_info(Platform, this, param_name);
+        return pyopencl_get_str_info(Platform, data(), param_name);
     default:
         throw clerror("Platform.get_info", CL_INVALID_VALUE);
     }

--- a/src/c_wrapper/program.cpp
+++ b/src/c_wrapper/program.cpp
@@ -18,7 +18,7 @@ new_program(cl_program prog, program_kind_type progkind=KND_UNKNOWN)
 
 program::~program()
 {
-    pyopencl_call_guarded_cleanup(clReleaseProgram, this);
+    pyopencl_call_guarded_cleanup(clReleaseProgram, data());
 }
 
 generic_info
@@ -26,25 +26,25 @@ program::get_info(cl_uint param) const
 {
     switch ((cl_program_info)param) {
     case CL_PROGRAM_CONTEXT:
-        return pyopencl_get_opaque_info(context, Program, this, param);
+        return pyopencl_get_opaque_info(context, Program, data(), param);
     case CL_PROGRAM_REFERENCE_COUNT:
     case CL_PROGRAM_NUM_DEVICES:
-        return pyopencl_get_int_info(cl_uint, Program, this, param);
+        return pyopencl_get_int_info(cl_uint, Program, data(), param);
     case CL_PROGRAM_DEVICES:
-        return pyopencl_get_opaque_array_info(device, Program, this, param);
+        return pyopencl_get_opaque_array_info(device, Program, data(), param);
     case CL_PROGRAM_SOURCE:
-        return pyopencl_get_str_info(Program, this, param);
+        return pyopencl_get_str_info(Program, data(), param);
     case CL_PROGRAM_BINARY_SIZES:
-        return pyopencl_get_array_info(size_t, Program, this, param);
+        return pyopencl_get_array_info(size_t, Program, data(), param);
     case CL_PROGRAM_BINARIES: {
-        auto sizes = pyopencl_get_vec_info(size_t, Program, this,
+        auto sizes = pyopencl_get_vec_info(size_t, Program, data(),
                                            CL_PROGRAM_BINARY_SIZES);
         pyopencl_buf<char*> result_ptrs(sizes.len());
         for (size_t i  = 0;i < sizes.len();i++) {
             result_ptrs[i] = (char*)malloc(sizes[i]);
         }
         try {
-            pyopencl_call_guarded(clGetProgramInfo, this, CL_PROGRAM_BINARIES,
+            pyopencl_call_guarded(clGetProgramInfo, data(), CL_PROGRAM_BINARIES,
                                   sizes.len() * sizeof(char*),
                                   result_ptrs.get(), nullptr);
         } catch (...) {
@@ -65,9 +65,9 @@ program::get_info(cl_uint param) const
 
 #if PYOPENCL_CL_VERSION >= 0x1020
     case CL_PROGRAM_NUM_KERNELS:
-        return pyopencl_get_int_info(size_t, Program, this, param);
+        return pyopencl_get_int_info(size_t, Program, data(), param);
     case CL_PROGRAM_KERNEL_NAMES:
-        return pyopencl_get_str_info(Program, this, param);
+        return pyopencl_get_str_info(Program, data(), param);
 #endif
     default:
         throw clerror("Program.get_info", CL_INVALID_VALUE);
@@ -80,14 +80,14 @@ program::get_build_info(const device *dev, cl_program_build_info param) const
     switch (param) {
     case CL_PROGRAM_BUILD_STATUS:
         return pyopencl_get_int_info(cl_build_status, ProgramBuild,
-                                     this, dev, param);
+                                     data(), dev, param);
     case CL_PROGRAM_BUILD_OPTIONS:
     case CL_PROGRAM_BUILD_LOG:
-        return pyopencl_get_str_info(ProgramBuild, this, dev, param);
+        return pyopencl_get_str_info(ProgramBuild, data(), dev, param);
 #if PYOPENCL_CL_VERSION >= 0x1020
     case CL_PROGRAM_BINARY_TYPE:
         return pyopencl_get_int_info(cl_program_binary_type, ProgramBuild,
-                                     this, dev, param);
+                                     data(), dev, param);
 #endif
     default:
         throw clerror("Program.get_build_info", CL_INVALID_VALUE);
@@ -102,7 +102,7 @@ program::compile(const char *opts, const clobj_t *_devs, size_t num_devs,
 {
     const auto devs = buf_from_class<device>(_devs, num_devs);
     const auto prgs = buf_from_class<program>(_prgs, num_hdrs);
-    pyopencl_call_guarded(clCompileProgram, this, devs, opts, prgs,
+    pyopencl_call_guarded(clCompileProgram, data(), devs, opts, prgs,
                           buf_arg(names, num_hdrs), nullptr, nullptr);
 }
 #endif
@@ -111,10 +111,10 @@ pyopencl_buf<clobj_t>
 program::all_kernels()
 {
     cl_uint num_knls;
-    pyopencl_call_guarded(clCreateKernelsInProgram, this, 0, nullptr,
+    pyopencl_call_guarded(clCreateKernelsInProgram, data(), 0, nullptr,
                           buf_arg(num_knls));
     pyopencl_buf<cl_kernel> knls(num_knls);
-    pyopencl_call_guarded(clCreateKernelsInProgram, this, knls,
+    pyopencl_call_guarded(clCreateKernelsInProgram, data(), knls,
                           buf_arg(num_knls));
     return buf_to_base<kernel>(knls, true);
 }

--- a/src/c_wrapper/program.h
+++ b/src/c_wrapper/program.h
@@ -25,7 +25,7 @@ public:
         : clobj(prog), m_program_kind(progkind)
     {
         if (retain) {
-            pyopencl_call_guarded(clRetainProgram, this);
+            pyopencl_call_guarded(clRetainProgram, data());
         }
     }
     ~program();
@@ -37,7 +37,7 @@ public:
     PYOPENCL_USE_RESULT pyopencl_buf<cl_device_id>
     get_info__devices() const
     {
-        return pyopencl_get_vec_info(cl_device_id, Program, this,
+        return pyopencl_get_vec_info(cl_device_id, Program, data(),
                                      CL_PROGRAM_DEVICES);
     }
     generic_info get_info(cl_uint param_name) const;

--- a/src/c_wrapper/sampler.cpp
+++ b/src/c_wrapper/sampler.cpp
@@ -10,7 +10,7 @@ template void print_buf<cl_sampler>(std::ostream&, const cl_sampler*,
 
 sampler::~sampler()
 {
-    pyopencl_call_guarded_cleanup(clReleaseSampler, this);
+    pyopencl_call_guarded_cleanup(clReleaseSampler, data());
 }
 
 generic_info
@@ -18,16 +18,16 @@ sampler::get_info(cl_uint param_name) const
 {
     switch ((cl_sampler_info)param_name) {
     case CL_SAMPLER_REFERENCE_COUNT:
-        return pyopencl_get_int_info(cl_uint, Sampler, this, param_name);
+        return pyopencl_get_int_info(cl_uint, Sampler, data(), param_name);
     case CL_SAMPLER_CONTEXT:
-        return pyopencl_get_opaque_info(context, Sampler, this, param_name);
+        return pyopencl_get_opaque_info(context, Sampler, data(), param_name);
     case CL_SAMPLER_ADDRESSING_MODE:
         return pyopencl_get_int_info(cl_addressing_mode, Sampler,
-                                     this, param_name);
+                                     data(), param_name);
     case CL_SAMPLER_FILTER_MODE:
-        return pyopencl_get_int_info(cl_filter_mode, Sampler, this, param_name);
+        return pyopencl_get_int_info(cl_filter_mode, Sampler, data(), param_name);
     case CL_SAMPLER_NORMALIZED_COORDS:
-        return pyopencl_get_int_info(cl_bool, Sampler, this, param_name);
+        return pyopencl_get_int_info(cl_bool, Sampler, data(), param_name);
 
     default:
         throw clerror("Sampler.get_info", CL_INVALID_VALUE);

--- a/src/c_wrapper/sampler.h
+++ b/src/c_wrapper/sampler.h
@@ -19,7 +19,7 @@ public:
         : clobj(samp)
     {
         if (retain) {
-            pyopencl_call_guarded(clRetainSampler, this);
+            pyopencl_call_guarded(clRetainSampler, data());
         }
     }
     ~sampler();


### PR DESCRIPTION
The error was that `clobj<CLType>` was passed where `CLType` was expected. I'm not sure why this was ever supposed to work; I tried putting a type-cast operator on `clobj`, but that didn't work.

Fixes #81.