### PR TITLE
Explicitly cache-dir configuration

### DIFF
--- a/doc/runtime.rst
+++ b/doc/runtime.rst
@@ -124,7 +124,7 @@ Platforms, Devices and Contexts
 
     Two instances of this class may be compared using *=="* and *"!="*.
 
-.. class:: Context(devices=None, properties=None, dev_type=None)
+.. class:: Context(devices=None, properties=None, dev_type=None, cache_dir=None)
 
     Create a new context. *properties* is a list of key-value
     tuples, where each key must be one of :class:`context_properties`.
@@ -133,6 +133,9 @@ Platforms, Devices and Contexts
     *dev_type* is one of the :class:`device_type` constants.
     If neither is specified, a context with a *dev_type* of
     :attr:`device_type.DEFAULT` is created.
+
+    If *cache_dir* is not `None` - it will be used as default *cache_dir*
+    for all its' :class:`Program` instances builds (see also :meth:`Program.build`).
 
     .. note::
 
@@ -654,12 +657,17 @@ Programs and Kernels
 
         See :class:`program_build_info` for values of *param*.
 
-    .. method:: build(options=[], devices=None)
+    .. method:: build(options=[], devices=None, cache_dir=None)
 
         *options* is a string of compiler flags.
         Returns *self*.
 
-        By default, built binaries are cached in an on-disk cache called
+        If *cache_dir* is not None - built binaries are cached in an on-disk cache
+        with given path.
+        If passed *cache_dir* is None, but context of this program was created with
+        not-None cache_dir - it will be used as cache directory.
+        If passed *cache_dir* is None and context was created with None cache_dir:
+        built binaries will be cached in an on-disk cache called
         :file:`pyopencl-compiler-cache-vN-uidNAME-pyVERSION` in the directory
         returned by :func:`tempfile.gettempdir`.  By setting the environment
         variable :envvar:`PYOPENCL_NO_CACHE` to any non-empty value, this

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -347,6 +347,9 @@ class Program(object):
         elif isinstance(options, six.text_type):
             options = [options.encode("utf8")]
 
+        if cache_dir is None:
+            cache_dir = self._context.cache_dir
+
         options = (options
                 + _DEFAULT_BUILD_OPTIONS
                 + _DEFAULT_INCLUDE_OPTIONS
@@ -1208,7 +1211,7 @@ _add_functionality()
 
 # {{{ convenience
 
-def create_some_context(interactive=None, answers=None):
+def create_some_context(interactive=None, answers=None, cache_dir=None):
     import os
     if answers is None:
         if "PYOPENCL_CTX" in os.environ:
@@ -1219,7 +1222,7 @@ def create_some_context(interactive=None, answers=None):
             from pyopencl.tools import get_test_platforms_and_devices
             for plat, devs in get_test_platforms_and_devices():
                 for dev in devs:
-                    return Context([dev])
+                    return Context([dev], cache_dir=cache_dir)
 
     if answers is not None:
         pre_provided_answers = answers
@@ -1334,7 +1337,7 @@ def create_some_context(interactive=None, answers=None):
         raise RuntimeError("not all provided choices were used by "
                 "create_some_context. (left over: '%s')" % ":".join(answers))
 
-    return Context(devices)
+    return Context(devices, cache_dir=cache_dir)
 
 _csc = create_some_context
 

--- a/pyopencl/cffi_cl.py
+++ b/pyopencl/cffi_cl.py
@@ -641,7 +641,7 @@ def _parse_context_properties(properties):
 class Context(_Common):
     _id = 'context'
 
-    def __init__(self, devices=None, properties=None, dev_type=None):
+    def __init__(self, devices=None, properties=None, dev_type=None, cache_dir=None):
         c_props = _parse_context_properties(properties)
         status_code = _ffi.new('cl_int*')
 
@@ -665,6 +665,7 @@ class Context(_Common):
                                                         dev_type))
 
         self.ptr = _ctx[0]
+        self.cache_dir = cache_dir
 
 # }}}
 


### PR DESCRIPTION
Optional param `cache_dir` in **Context** constructor added.
Documentation about **Context** constructor and **Program.build** actualized: cache dir description updated in accordance with code.

This is a fix for https://github.com/pyopencl/pyopencl/issues/97