### PR TITLE
Fixes to enqueue_copy_buffer_rect

### DIFF
--- a/pyopencl/cffi_cl.py
+++ b/pyopencl/cffi_cl.py
@@ -1406,9 +1406,13 @@ def _enqueue_copy_buffer_rect(queue, src, dst, src_origin, dst_origin, region,
     if src_pitches is None:
         src_pitches = _ffi.NULL
         src_pitches_l = 0
+    else:
+        src_pitches_l = len(src_pitches)
     if dst_pitches is None:
         dst_pitches = _ffi.NULL
         dst_pitches_l = 0
+    else:
+        dst_pitches_l = len(dst_pitches)
     src_origin_l = len(src_origin)
     dst_origin_l = len(dst_origin)
     region_l = len(region)

--- a/src/c_wrapper/utils.h
+++ b/src/c_wrapper/utils.h
@@ -386,10 +386,8 @@ public:
     {
         if (l < n) {
             memcpy(m_intern_buf, buf, type_size<T>::value * l);
-            if (content) {
-                for (size_t i = l;i < n;i++) {
-                    m_intern_buf[i] = content;
-                }
+            for (size_t i = l;i < n;i++) {
+                m_intern_buf[i] = content;
             }
             this->set(m_intern_buf);
         }


### PR DESCRIPTION
There are two bugs:
1. If src_pitches or dst_pitches is specified, there is an uninitialised
   variable.
2. If ConstBuffer is given a short array and content==0, the internal
   buffer is not zero-filled, causing garbage to be passed on.

The latter probably affects a lot of other functions, but hopefully in a
positive way.

Fixes #105.