### PR TITLE
Fix indexing with reverse slices

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -1568,7 +1568,7 @@ class Array(object):
 
                 array_stride = self.strides[array_axis]
 
-                new_shape.append((stop-start-1)//idx_stride+1)
+                new_shape.append((abs(stop-start)-1)//abs(idx_stride)+1)
                 new_strides.append(idx_stride*array_stride)
                 new_offset += array_stride*start
 


### PR DESCRIPTION
An earlier commit fixed a rounding issue for slices with steps > 1, but it broke reverse indexing, where step < 0.  This fix should re-enable reverse indexing.