### PR TITLE
Reworked how PyOpenCL module finds its path

### DIFF
--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -232,13 +232,21 @@ del _size_t_char
 # {{{ find pyopencl shipped source code
 
 def _find_pyopencl_include_path():
-    from os.path import join, abspath, dirname, exists
+    from pkg_resources import Requirement, resource_filename, DistributionNotFound
+    try:
+        # Try to find the resource with pkg_resources (the recommended setuptools approach)
+        return resource_filename(Requirement.parse("pyopencl2"), "pyopencl/cl")
+    except DistributionNotFound:
+        # If pkg_resources can't find it (e.g. if the module is part of a frozen application),
+        # try to find the include path in the same directory as this file 
+        from os.path import join, abspath, dirname, exists
     
-    include_path = join(abspath(dirname(__file__)), "cl")
-    if not exists(include_path):
-        raise RuntimeError("Could not located PyOpenCL include path")
-        
-    return include_path
+        include_path = join(abspath(dirname(__file__)), "cl")
+        # If that doesn't exist, just re-raise the exception caught from resource_filename
+        if not exists(include_path):
+            raise
+            
+        return include_path
 
 # }}}
 

--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -232,8 +232,13 @@ del _size_t_char
 # {{{ find pyopencl shipped source code
 
 def _find_pyopencl_include_path():
-    from pkg_resources import Requirement, resource_filename
-    return resource_filename(Requirement.parse("pyopencl"), "pyopencl/cl")
+    from os.path import join, abspath, dirname, exists
+    
+    include_path = join(abspath(dirname(__file__)), "cl")
+    if not exists(include_path):
+        raise RuntimeError("Could not located PyOpenCL include path")
+        
+    return include_path
 
 # }}}
 


### PR DESCRIPTION
[Previously](https://github.com/pyopencl/pyopencl/blob/master/pyopencl/__init__.py#L234), `pkg_resources` was used to find the location of the PyOpenCL module so that the include path could be constructed.
This commit replaces that by simply using the [`__file__`](https://github.com/jmc734/pyopencl/blob/master/pyopencl/__init__.py#L237) and [`os.path`](https://github.com/jmc734/pyopencl/blob/master/pyopencl/__init__.py#L235) utilities

This change fixes an incompatibility with PyOpenCL and pyinstaller/cxfreeze/etc. When frozen, distutils is not able to resolve the PyOpenCL package directly and subsequently raises a DistributionNotFound error. Since we are the PyOpenCL package, we don't need to be using distutils to resolve it. This issue was [reported](https://lists.tiker.net/pipermail/pyopencl/2014-October/001832.html) by someone else in the pyopencl mailing list as well.