### PR TITLE
Allow for spaces in installation path

### DIFF
--- a/pyopencl/__init__.py
+++ b/pyopencl/__init__.py
@@ -257,7 +257,7 @@ def _find_pyopencl_include_path():
 # {{{ Program (including caching support)
 
 _DEFAULT_BUILD_OPTIONS = []
-_DEFAULT_INCLUDE_OPTIONS = ["-I", _find_pyopencl_include_path()]
+_DEFAULT_INCLUDE_OPTIONS = ["-I", "'" + _find_pyopencl_include_path() + "'"]
 
 # map of platform.name to build options list
 _PLAT_BUILD_OPTIONS = {}


### PR DESCRIPTION
Fixes INVALID_COMPUTER_OPTIONS error if PyOpenCL installation path includes spaces