### PR TITLE
Adding ability to build with GL interop from pip command

### DIFF
--- a/pyopencl/version.py
+++ b/pyopencl/version.py
@@ -1,3 +1,3 @@
-VERSION = (2015, 2, 4)
+VERSION = (2016, 1)
 VERSION_STATUS = ""
 VERSION_TEXT = ".".join(str(x) for x in VERSION) + VERSION_STATUS

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,19 @@ def main():
     conf = get_config(get_config_schema(),
             warn_about_no_config=False)
 
+
+    custom_args = ['CL_ENABLE_GL', 'CL_TRACE', 'CL_PRETEND_VERSION']
+
+    new_argv = []
+    for word in sys.argv:
+        arg = word.split('=', 1)
+        k, v = (arg[0], True) if (len(arg) == 1) else arg
+        if k in custom_args:    # if it's one of our options
+            conf[k] = v         # update config
+        else:
+            new_argv.append(word)     # remove from argv so setuptools doesn't get mad
+    sys.argv = new_argv
+
     extra_defines = {}
 
     extra_defines["PYGPU_PACKAGE"] = "pyopencl"


### PR DESCRIPTION
This is my first pull request, so sorry if it's not right.

The old method of pip install defaults to not including opengl interop as some setups will not have GL. A build switch is used with configure.py to turn it on, but that's not something that could be done from setup.py. I have modified setup.py such that it can take extra arguments, which are able to be passed in from pip using the "--install-option" switch. This seems to allow me to use pip to turn on gl interop in the build without any special configuration files or commands. I hope it will work similarly from PyPI.

tested in the "pyopencl" directory using
```pip install . --install-option="CL_ENABLE_GL"```
followed by running the gl_interop_demo.py from the examples directory.