### PR TITLE
Wrappers for nvidia CL_DEVICE_PCI_BUS_ID_NV, etc device attributes

### DIFF
--- a/doc/make_constants.py
+++ b/doc/make_constants.py
@@ -97,6 +97,9 @@ const_ext_lookup = {
             "GPU_OVERLAP_NV": nv_devattr,
             "KERNEL_EXEC_TIMEOUT_NV": nv_devattr,
             "INTEGRATED_MEMORY_NV": nv_devattr,
+            "ATTRIBUTE_ASYNC_ENGINE_COUNT_NV": nv_devattr,
+            "PCI_BUS_ID_NV": nv_devattr,
+            "PCI_SLOT_ID_NV": nv_devattr,
 
             "DOUBLE_FP_CONFIG":
             ("cl_khr_fp64", "2011.1"),

--- a/src/c_wrapper/device.cpp
+++ b/src/c_wrapper/device.cpp
@@ -143,6 +143,9 @@ device::get_info(cl_uint param_name) const
     case CL_DEVICE_COMPUTE_CAPABILITY_MINOR_NV:
     case CL_DEVICE_REGISTERS_PER_BLOCK_NV:
     case CL_DEVICE_WARP_SIZE_NV:
+    case CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV:
+    case CL_DEVICE_PCI_BUS_ID_NV:
+    case CL_DEVICE_PCI_SLOT_ID_NV:
         return DEV_GET_INT_INF(cl_uint);
     case CL_DEVICE_GPU_OVERLAP_NV:
     case CL_DEVICE_KERNEL_EXEC_TIMEOUT_NV:

--- a/src/c_wrapper/wrap_cl.h
+++ b/src/c_wrapper/wrap_cl.h
@@ -157,6 +157,20 @@ extern "C" {
 #define PYOPENCL_USE_RESULT
 #endif
 
+#ifdef CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV
+
+#ifndef CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV
+#define CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV   0x4007
+#endif
+#ifndef CL_DEVICE_PCI_BUS_ID_NV
+#define CL_DEVICE_PCI_BUS_ID_NV                     0x4008
+#endif
+#ifndef CL_DEVICE_PCI_SLOT_ID_NV
+#define CL_DEVICE_PCI_SLOT_ID_NV                    0x4009
+#endif
+
+#endif // CL_DEVICE_COMPUTE_CAPABILITY_MAJOR_NV
+
 #endif
 
 // vim: foldmethod=marker

--- a/src/c_wrapper/wrap_constants.cpp
+++ b/src/c_wrapper/wrap_constants.cpp
@@ -201,6 +201,9 @@ void populate_constants(void(*add)(const char*, const char*, int64_t value))
     ADD_ATTR("device_info", DEVICE_, GPU_OVERLAP_NV);
     ADD_ATTR("device_info", DEVICE_, KERNEL_EXEC_TIMEOUT_NV);
     ADD_ATTR("device_info", DEVICE_, INTEGRATED_MEMORY_NV);
+    ADD_ATTR("device_info", DEVICE_, ATTRIBUTE_ASYNC_ENGINE_COUNT_NV);
+    ADD_ATTR("device_info", DEVICE_, PCI_BUS_ID_NV);
+    ADD_ATTR("device_info", DEVICE_, PCI_SLOT_ID_NV);
 #endif
 #ifdef CL_DEVICE_PROFILING_TIMER_OFFSET_AMD
     ADD_ATTR("device_info", DEVICE_, PROFILING_TIMER_OFFSET_AMD);


### PR DESCRIPTION
Hi, sorry to bug you again...Wondering if it is OK to add some nvidia-specific
device attributes:

   a. `CL_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT_NV`
   b. `CL_DEVICE_PCI_BUS_ID_NV`
   c. `CL_DEVICE_PCI_SLOT_ID_NV`

Trying to do `multiprocessing` on multiple GPUs and the PCI_BUS_ID and PCI_SLOT_ID
attributes seem to be the only/best way to identify a device? `ATTRIBUTE_ASYNC_ENGINE_COUNT` is there just for completeness.

Not sure if the additions in `src/c_wrapper/wrap_cl.h` are in the right place,
seems to be the only spot where `cl_ext.h` is included...

I would have had a crack at the AMD *topology* but I don't have any AMD hardware
to test it on....