### PR TITLE
Fix error when decoding a NULL string

### DIFF
--- a/pyopencl/cffi_cl.py
+++ b/pyopencl/cffi_cl.py
@@ -99,7 +99,7 @@ except:
     _bytes = bytes
 
     def _ffi_pystr(s):
-        return _ffi.string(s).decode()
+        return _ffi.string(s).decode() if s else None
 else:
     try:
         _bytes = bytes


### PR DESCRIPTION
If some device info is NULL  then this line would cause a RuntimeError: cannot use string() on <cdata 'char *' NULL>.

For example, in my PC, the Intel CPU runtime under Linux has BUILT_IN_KERNELS = NULL.