### PR TITLE
fix issue #130

### DIFF
--- a/pyopencl/tools.py
+++ b/pyopencl/tools.py
@@ -558,14 +558,14 @@ def match_dtype_to_c_struct(device, name, dtype, context=None):
 
     src = r"""
         #define pycl_offsetof(st, m) \
-                 ((size_t) ((__local char *) &(dummy.m) \
+                 ((uint) ((__local char *) &(dummy.m) \
                  - (__local char *)&dummy ))
 
         %(pre_decls)s
 
         %(my_decl)s
 
-        __kernel void get_size_and_offsets(__global size_t *result)
+        __kernel void get_size_and_offsets(__global uint *result)
         {
             result[0] = sizeof(%(my_type)s);
             __local %(my_type)s dummy;
@@ -586,7 +586,7 @@ def match_dtype_to_c_struct(device, name, dtype, context=None):
     knl = prg.build(devices=[device]).get_size_and_offsets
 
     import pyopencl.array  # noqa
-    result_buf = cl.array.empty(queue, 1+len(fields), np.uintp)
+    result_buf = cl.array.empty(queue, 1+len(fields), np.uint32)
     knl(queue, (1,), (1,), result_buf.data)
     queue.finish()
     size_and_offsets = result_buf.get()


### PR DESCRIPTION
Fix the match_dtype_to_c_struct function in the case where numpy.intp size differs from sizeof(size_t) in opencl. Most of the time this will happen on a 64bit system with an opencl device that declares CL_DEVICE_ADDRESS_BITS to only 32bits. 