### PR TITLE
Update benchmark.py - Fixing compiler warning

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -54,6 +54,7 @@ for platform in cl.get_platforms():
         dest_buf = cl.Buffer(ctx, mf.WRITE_ONLY, b.nbytes)
 
         prg = cl.Program(ctx, """
+            #pragma OPENCL EXTENSION cl_khr_fp64 : enable
             __kernel void sum(__global const float *a,
             __global const float *b, __global float *c)
             {

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -54,7 +54,6 @@ for platform in cl.get_platforms():
         dest_buf = cl.Buffer(ctx, mf.WRITE_ONLY, b.nbytes)
 
         prg = cl.Program(ctx, """
-            #pragma OPENCL EXTENSION cl_khr_fp64 : enable
             __kernel void sum(__global const float *a,
             __global const float *b, __global float *c)
             {
@@ -68,7 +67,7 @@ for platform in cl.get_platforms():
                         
                         c_temp = a_temp+b_temp; // sum of my elements
                         c_temp = c_temp * c_temp; // product of sums
-                        c_temp = c_temp * (a_temp/2.0); // times 1/2 my a
+                        c_temp = c_temp * (a_temp/2.0f); // times 1/2 my a
 
                         c[gid] = c_temp; // store result in global memory
                 }


### PR DESCRIPTION
Fixing CompilerWarning: `<program source>: warning: double precision constant requires cl_khr_fp64, casting to single precision`
Based on [documentation](https://www.khronos.org/registry/cl/sdk/1.0/docs/man/xhtml/cl_khr_fp64.html), An application that wants to use double will need to include the directive before any double precision data type is declared in the kernel code.