### PR TITLE
Image processing median filter

### DIFF
--- a/examples/median-filter.py
+++ b/examples/median-filter.py
@@ -22,3 +22,64 @@ else:
 # Create queue for each kernel execution
 queue = cl.CommandQueue(ctx)
 mf = cl.mem_flags
+
+
+# Kernel function
+src = '''
+void sort(int *a, int *b, int *c) {
+   int swap;
+   if(*a > *b) {
+      swap = *a;
+      *a = *b;
+      *b = swap;
+   }
+   if(*a > *c) {
+      swap = *a;
+      *a = *c;
+      *c = swap;
+   }
+   if(*b > *c) {
+      swap = *b;
+      *b = *c;
+      *c = swap;
+   }
+}
+__kernel void medianFilter(__global float *img, __global float *res, __global int *width, __global int *height)
+{
+    int w = *width;
+    int h = *height;
+    int posx = get_global_id(1);
+    int posy = get_global_id(0);
+    int i = w*posy + posx;
+    // Keeping the edge pixels the same
+    if( posx == 0 || posy == 0 || posx == w-1 || posy == h-1 )
+    {
+        res[ i ] = img[ i ];
+    }
+    else
+    {
+        int pixel00, pixel01, pixel02, pixel10, pixel11, pixel12, pixel20, pixel21, pixel22;
+        pixel00 = img[i - 1 - w];
+        pixel01 = img[i- w];
+        pixel02 = img[i + 1 - w];
+        pixel10 = img[i - 1];
+        pixel11 = img[i];
+        pixel12 = img[i + 1];
+        pixel20 = img[i - 1 + w];
+        pixel21 = img[i + w];
+        pixel22 = img[i + 1 + w];
+        //sort the rows
+        sort( &(pixel00), &(pixel01), &(pixel02) );
+        sort( &(pixel10), &(pixel11), &(pixel12) );
+        sort( &(pixel20), &(pixel21), &(pixel22) );
+        //sort the columns
+        sort( &(pixel00), &(pixel10), &(pixel20) );
+        sort( &(pixel01), &(pixel11), &(pixel21) );
+        sort( &(pixel02), &(pixel12), &(pixel22) );
+        //sort the diagonal
+        sort( &(pixel00), &(pixel11), &(pixel22) );
+        // median is the the middle value of the diagonal
+        res [ i ] = pixel11;
+    }
+}
+'''

--- a/examples/median-filter.py
+++ b/examples/median-filter.py
@@ -1,0 +1,24 @@
+import pyopencl as cl
+import numpy as np
+from scipy.misc import imread, imsave
+
+#Read in image
+img = imread('noisyImage.jpg', flatten=True).astype(np.float32)
+
+# Get platforms, both CPU and GPU
+plat = cl.get_platforms()
+CPU = plat[0].get_devices()
+try:
+    GPU = plat[1].get_devices()
+except IndexError:
+    GPU = "none"
+
+#Create context for GPU/CPU
+if GPU!= "none":
+    ctx = cl.Context(GPU)
+else:
+    ctx = cl.Context(CPU)
+
+# Create queue for each kernel execution
+queue = cl.CommandQueue(ctx)
+mf = cl.mem_flags


### PR DESCRIPTION
Example showing how to leverage OpenCL to do image processing. The kernel function applies a median filter on each pixel of a gray-scale image. This example may be useful for anyone using OpenCL to do image processing in parallel (pixel by pixel).