### PR TITLE
Fix error messages and ability to pass a queue in all cases of setitem flow

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -364,7 +364,7 @@ class Array(object):
         if queue is not None:
             warn("Passing the queue to the array through anything but the "
                     "first argument of the Array constructor is deprecated. "
-                    "This will be continue to be accepted throughout the "
+                    "This will continue to be accepted throughout the "
                     "2013.[0-6] versions of PyOpenCL.",
                     DeprecationWarning, 2)
 
@@ -1203,7 +1203,7 @@ class Array(object):
                         "multidimensional fancy indexing is not supported")
             if len(self.shape) != 1:
                 raise NotImplementedError(
-                        "fancy indexing into a multi-d array is supported")
+                        "fancy indexing into a multi-d array is not supported")
 
             multi_put([value], subscript, out=[self], queue=self.queue)
             return

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -1194,6 +1194,8 @@ class Array(object):
         .. versionadded:: 2013.1
         """
 
+        queue = queue or self.queue or value.queue
+
         if isinstance(subscript, Array):
             if subscript.dtype.kind != "i":
                 raise TypeError(
@@ -1205,10 +1207,8 @@ class Array(object):
                 raise NotImplementedError(
                         "fancy indexing into a multi-d array is not supported")
 
-            multi_put([value], subscript, out=[self], queue=self.queue)
+            multi_put([value], subscript, out=[self], queue=queue)
             return
-
-        queue = queue or self.queue or value.queue
 
         subarray = self[subscript]
 


### PR DESCRIPTION
I fixed some confusing exception and warning messages. I also noticed that contrary to the docstring for `setitem`, it was not possible to pass a queue as an arg into `mutli_put` from `setitem`.