### PR TITLE
Fix Exception message and allow queue arg usage for `multi_put`.

### DIFF
--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -1661,7 +1661,7 @@ class Array(object):
                         "multidimensional fancy indexing is not supported")
             if len(self.shape) != 1:
                 raise NotImplementedError(
-                        "fancy indexing into a multi-d array is supported")
+                        "fancy indexing into a multi-d array is not supported")
 
             multi_put([value], subscript, out=[self], queue=queue,
                     wait_for=wait_for)

--- a/pyopencl/array.py
+++ b/pyopencl/array.py
@@ -1650,6 +1650,8 @@ class Array(object):
             Added *wait_for*.
         """
 
+        queue = queue or self.queue or value.queue
+
         if isinstance(subscript, Array):
             if subscript.dtype.kind != "i":
                 raise TypeError(
@@ -1661,11 +1663,9 @@ class Array(object):
                 raise NotImplementedError(
                         "fancy indexing into a multi-d array is supported")
 
-            multi_put([value], subscript, out=[self], queue=self.queue,
+            multi_put([value], subscript, out=[self], queue=queue,
                     wait_for=wait_for)
             return
-
-        queue = queue or self.queue or value.queue
 
         subarray = self[subscript]
 


### PR DESCRIPTION
I noticed a confusing Exception message missing a `not`. Also fix issue where the passed queue arg in `Array.setitem` was not being passed onto the `multi_put` call.